### PR TITLE
Körtagság listázás api

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ találod. A telepítéshez szükséges információk valószínűleg a
 * körök konfigurációs mappa megléte
 * Git
 * Maven
-* JDK (1.7+)
+* JDK (1.8+)
 
 ### PostgreSQL konfig
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -135,6 +135,10 @@ A projekt főkönyvtárából:
 
     mvn -DskipTests clean package wildfly:deploy
 
+Amennyiben az éles rendszerre fordítasz használdt a `production` maven profilt:
+
+    mvn -DskipTests clean package wildfly:deploy -P production
+
 ## Front-end
 
 TBA

--- a/docs/install.md
+++ b/docs/install.md
@@ -135,7 +135,7 @@ A projekt főkönyvtárából:
 
     mvn -DskipTests clean package wildfly:deploy
 
-Amennyiben az éles rendszerre fordítasz használdt a `production` maven profilt:
+Amennyiben az éles rendszerre fordítasz használd a `production` maven profilt:
 
     mvn -DskipTests clean package wildfly:deploy -P production
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,9 @@
         <maven.compiler.source>1.7</maven.compiler.source>
 
         <!-- dependency versions -->
+
+        <!-- resource filtering properties -->
+        <persistence.hibernate.show_sql>true</persistence.hibernate.show_sql>
     </properties>
 
     <modules>
@@ -380,4 +383,13 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>production</id>
+            <properties>
+                <persistence.hibernate.show_sql>false</persistence.hibernate.show_sql>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
         <version.jar.plugin>2.4</version.jar.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
 
         <!-- dependency versions -->
 

--- a/sch-pek-domain/pom.xml
+++ b/sch-pek-domain/pom.xml
@@ -22,6 +22,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
     <dependencies>
         <dependency>

--- a/sch-pek-domain/src/main/java/hu/sch/domain/Group.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/Group.java
@@ -3,6 +3,7 @@ package hu.sch.domain;
 import hu.sch.domain.enums.GroupStatus;
 import hu.sch.domain.user.User;
 import hu.sch.domain.logging.Log;
+import hu.sch.domain.util.MembershipSorter;
 import hu.sch.util.HungarianStringComparator;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -312,8 +313,7 @@ public class Group implements Serializable, Comparable<Group> {
     }
 
     private void loadMembers() {
-        sortMemberships();
-        List<Membership> list = getMemberships();
+        List<Membership> list = new MembershipSorter(getMemberships()).sort();
 
         members = new ArrayList<>(list.size());
         activeMemberships = new ArrayList<>();
@@ -348,20 +348,6 @@ public class Group implements Serializable, Comparable<Group> {
             loadMembers();
         }
         return inactiveMemberships;
-    }
-
-    public void sortMemberships() {
-        if (getMemberships() != null) {
-            Collections.sort(getMemberships(), new Comparator<Membership>() {
-                @Override
-                public int compare(Membership o1, Membership o2) {
-                    if (o1.getEnd() == null ^ o2.getEnd() == null) {
-                        return o1.getEnd() == null ? -1 : 1;
-                    }
-                    return o1.getUser().compareTo(o2.getUser());
-                }
-            });
-        }
     }
 
     public List<Log> getLogs() {

--- a/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
@@ -65,14 +65,14 @@ public class Membership implements Serializable {
     private Long id;
     //----------------------------------------------------
     @ManyToOne(optional = false)
-    @JoinColumn(name = "grp_id", insertable = true, updatable = true)
+    @JoinColumn(name = "grp_id")
     private Group group;
     //----------------------------------------------------
     @Column(name = "grp_id", insertable = false, updatable = false)
     private Long groupId;
     //----------------------------------------------------
     @ManyToOne(optional = false)
-    @JoinColumn(name = "usr_id", insertable = true, updatable = true)
+    @JoinColumn(name = "usr_id")
     private User user;
     //----------------------------------------------------
     @Column(name = "usr_id", insertable = false, updatable = false)

--- a/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
@@ -30,11 +30,9 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "grp_membership")
 @NamedQueries(value = {
-    @NamedQuery(name = Membership.getMembership,
-            query = "SELECT ms FROM Membership ms WHERE ms.user = :user AND ms.group.isSvie = true"),
     @NamedQuery(name = Membership.getActiveSvieMemberships,
             query = "SELECT ms FROM Membership ms WHERE ms.user = :user AND ms.group.isSvie = true AND ms.end IS null"),
-    @NamedQuery(name = Membership.getMembers,
+    @NamedQuery(name = Membership.getMembersWithSvieMembershipTypeNotEqual,
             query = "SELECT u FROM User u WHERE u.svieMembershipType <> :msType"),
     @NamedQuery(name = Membership.getDelegatedMemberForGroup,
             query = "SELECT ms.user FROM Membership ms WHERE ms.group.id=:groupId AND ms.user.sviePrimaryMembership = ms AND ms.user.delegated = true"),
@@ -48,13 +46,9 @@ import javax.persistence.Transient;
 @SequenceGenerator(name = "grp_members_seq", sequenceName = "grp_members_seq", allocationSize = 1)
 public class Membership implements Serializable {
 
-    public static final String SORT_BY_GROUP = "group";
-    public static final String SORT_BY_POSTS = "postsAsString";
-    public static final String SORT_BY_INTERVAL = "interval";
     private static final long serialVersionUID = 1L;
-    public static final String getMembership = "getMembership";
     public static final String getActiveSvieMemberships = "getActiveSvieMemberships";
-    public static final String getMembers = "getMembers";
+    public static final String getMembersWithSvieMembershipTypeNotEqual = "getMembersWithSvieMembershipTypeNotEqual";
     public static final String getDelegatedMemberForGroup = "getDelegatedMemberForGroup";
     public static final String getAllDelegated = "getAllDelegated";
     public static final String findMembershipsForGroup = "findMembershipsForGroup";

--- a/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/Membership.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -213,10 +214,9 @@ public class Membership implements Serializable {
      * @return a list of posts
      */
     public List<String> getAllPosts() {
-        List<String> postList = new ArrayList<>();
-        for (Post post : getPosts()) {
-            postList.add(post.getPostType().getPostName());
-        }
+        List<String> postList = getPosts().stream()
+                .map(p -> p.getPostType().getPostName())
+                .collect(Collectors.toCollection(ArrayList::new));
 
         if (!isActive()) {
             postList.add(INACTIVE_MEMBERSHIP_POST);

--- a/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
@@ -389,21 +389,6 @@ public class User implements Serializable, Comparable<User> {
         return String.format("%s %s", getLastName(), getFirstName());
     }
 
-    public void sortMemberships() {
-        if (this.getMemberships() != null) {
-            Collections.sort(this.getMemberships(),
-                    new Comparator<Membership>() {
-                        @Override
-                        public int compare(Membership o1, Membership o2) {
-                            if (o1.getEnd() == null ^ o2.getEnd() == null) {
-                                return o1.getEnd() == null ? -1 : 1;
-                            }
-                            return o1.getGroup().compareTo(o2.getGroup());
-                        }
-                    });
-        }
-    }
-
     /**
      * A felhasználó választott felhasználóneve.
      *

--- a/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
@@ -30,8 +30,6 @@ import javax.xml.bind.annotation.XmlRootElement;
             query = "SELECT u FROM User u WHERE UPPER(u.neptunCode) = UPPER(:neptun)"),
     @NamedQuery(name = User.findByScreenName,
             query = "SELECT u FROM User u WHERE UPPER(u.screenName) = UPPER(:screenName)"),
-    @NamedQuery(name = User.findUser, query = "SELECT u FROM User u WHERE upper(u.neptunCode) = upper(:neptunkod) OR "
-            + "upper(u.emailAddress) = upper(:emailcim)"),
     @NamedQuery(name = User.getAllValuatedSemesterForUser, query = "SELECT DISTINCT pr.valuation.semester FROM PointRequest pr WHERE pr.user = :user ORDER BY pr.valuation.semester DESC")
 })
 @SequenceGenerator(name = "users_seq", sequenceName = "users_usr_id_seq",
@@ -43,7 +41,6 @@ public class User implements Serializable, Comparable<User> {
     private static final long serialVersionUID = 1L;
     public static final String findWithMemberships = "findUserWithMemberships";
     public static final String findUserByNeptunCode = "findUserByNeptunCode";
-    public static final String findUser = "findUser";
     public static final String findByScreenName = "findByScreenName";
     public static final String getAllValuatedSemesterForUser = "getAllValuatedSemesterForUser";
     //----------------------------------------------------
@@ -133,8 +130,8 @@ public class User implements Serializable, Comparable<User> {
     @Column(name = "usr_svie_member_type", nullable = false)
     private SvieMembershipType svieMembershipType;
     //----------------------------------------------------
-    @ManyToOne
-    @JoinColumn(name = "usr_svie_primary_membership", insertable = true, updatable = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usr_svie_primary_membership")
     private Membership sviePrimaryMembership;
     //----------------------------------------------------
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/user/User.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Table(name = "users")
 @NamedQueries({
     @NamedQuery(name = User.findWithMemberships,
-            query = "SELECT u FROM User u LEFT OUTER JOIN FETCH u.memberships WHERE u.id = :id"),
+            query = "SELECT u FROM User u LEFT JOIN FETCH u.memberships ms LEFT JOIN FETCH ms.posts posts LEFT JOIN FETCH ms.group LEFT JOIN FETCH posts.postType WHERE u.id = :id"),
     @NamedQuery(name = User.findUserByNeptunCode,
             query = "SELECT u FROM User u WHERE UPPER(u.neptunCode) = UPPER(:neptun)"),
     @NamedQuery(name = User.findByScreenName,
@@ -393,14 +393,14 @@ public class User implements Serializable, Comparable<User> {
         if (this.getMemberships() != null) {
             Collections.sort(this.getMemberships(),
                     new Comparator<Membership>() {
-                @Override
-                public int compare(Membership o1, Membership o2) {
-                    if (o1.getEnd() == null ^ o2.getEnd() == null) {
-                        return o1.getEnd() == null ? -1 : 1;
-                    }
-                    return o1.getGroup().compareTo(o2.getGroup());
-                }
-            });
+                        @Override
+                        public int compare(Membership o1, Membership o2) {
+                            if (o1.getEnd() == null ^ o2.getEnd() == null) {
+                                return o1.getEnd() == null ? -1 : 1;
+                            }
+                            return o1.getGroup().compareTo(o2.getGroup());
+                        }
+                    });
         }
     }
 

--- a/sch-pek-domain/src/main/java/hu/sch/domain/util/MembershipSorter.java
+++ b/sch-pek-domain/src/main/java/hu/sch/domain/util/MembershipSorter.java
@@ -1,0 +1,53 @@
+package hu.sch.domain.util;
+
+import hu.sch.domain.Membership;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ *
+ * @author tomi
+ */
+public class MembershipSorter {
+
+    private final Collection<Membership> memberships;
+
+    public MembershipSorter(Collection<Membership> memberships) {
+        this.memberships = memberships;
+    }
+
+    /**
+     * Sort memberships. Put active memberships first, but falls back to group
+     * name comparison when when memberships status (active or inactive) equals.
+     *
+     * It does not change the underlying {@link Membership} collection.
+     *
+     * @return a sorted list of memberships.
+     */
+    public List<Membership> sort() {
+        if (memberships == null) {
+            return Collections.emptyList();
+        }
+        List<Membership> result = new ArrayList<>(memberships);
+        Collections.sort(result, new MembershipComparator());
+
+        return result;
+    }
+
+    private static class MembershipComparator implements Comparator<Membership> {
+
+        @Override
+        public int compare(Membership ms1, Membership ms2) {
+            // put active before inactive memberships
+            if (ms1.getEnd() == null ^ ms2.getEnd() == null) {
+                return ms1.getEnd() == null ? -1 : 1;
+            }
+            // fallback to lexical sorting of group names
+            return ms1.getGroup().compareTo(ms2.getGroup());
+        }
+
+    }
+}

--- a/sch-pek-domain/src/main/resources/META-INF/persistence.xml
+++ b/sch-pek-domain/src/main/resources/META-INF/persistence.xml
@@ -9,9 +9,9 @@
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
 
         <properties>
-            <property name="hibernate.show_sql" value="false"/>
-            <property name="hibernate.format_sql" value="false" />
-            <property name="hibernate.use_sql_comments" value="false" />
+            <property name="hibernate.show_sql" value="${persistence.hibernate.show_sql}"/>
+            <property name="hibernate.format_sql" value="true" />
+            <property name="hibernate.use_sql_comments" value="true" />
             <property name="hibernate.bytecode.use_reflection_optimizer" value="true"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
             <property name="hibernate.jdbc.use_streams_for_binary" value="false"/>

--- a/sch-pek-domain/src/test/java/hu/sch/domain/MembershipTest.java
+++ b/sch-pek-domain/src/test/java/hu/sch/domain/MembershipTest.java
@@ -1,0 +1,62 @@
+package hu.sch.domain;
+
+import java.util.Date;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+import org.junit.Before;
+
+/**
+ *
+ * @author tomi
+ */
+public class MembershipTest {
+    private static final String TEST_POST_NAME = "test";
+
+    private Membership membership;
+
+    @Before
+    public void createMembership() {
+        membership = new Membership();
+    }
+
+    @Test
+    public void noPostMeansRegularMember() {
+        assertThat(membership.getAllPosts()).contains(Membership.ACTIVE_MEMBERSHIP_POST);
+    }
+
+    @Test
+    public void endedMembershipHasOregtagPost() {
+        membership.setEnd(new Date());
+        assertThat(membership.getAllPosts()).contains(Membership.INACTIVE_MEMBERSHIP_POST);
+    }
+
+    @Test
+    public void regularMembershipOnlyAppliesWhenThereAreNoOtherPosts() {
+        addPostToMembership(TEST_POST_NAME);
+        assertThat(membership.getAllPosts()).doesNotContain(Membership.ACTIVE_MEMBERSHIP_POST);
+    }
+
+    @Test
+    public void inactiveMembershipStillHasItsPosts() {
+        addPostToMembership(TEST_POST_NAME);
+        membership.setEnd(new Date());
+
+        assertThat(membership.getAllPosts()).contains(TEST_POST_NAME);
+    }
+
+    @Test
+    public void membershipCanHaveMultiplePosts() {
+        addPostToMembership(TEST_POST_NAME);
+        addPostToMembership(TEST_POST_NAME + "2");
+
+        assertThat(membership.getAllPosts()).hasSize(2);
+    }
+
+    private void addPostToMembership(String name) {
+        PostType pt = new PostType();
+        pt.setPostName(name);
+        Post p = new Post();
+        p.setPostType(pt);
+        membership.getPosts().add(p);
+    }
+}

--- a/sch-pek-domain/src/test/java/hu/sch/domain/util/MembershipSorterTest.java
+++ b/sch-pek-domain/src/test/java/hu/sch/domain/util/MembershipSorterTest.java
@@ -1,0 +1,50 @@
+package hu.sch.domain.util;
+
+import hu.sch.domain.Group;
+import hu.sch.domain.Membership;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import static org.assertj.core.api.Assertions.*;
+import org.junit.Test;
+
+/**
+ *
+ * @author tomi
+ */
+public class MembershipSorterTest {
+
+    @Test
+    public void activeMembershipIsBeforeInactive() {
+        Membership inactive = new Membership();
+        inactive.setEnd(new Date());
+        Membership active = new Membership();
+        List<Membership> list = Arrays.asList(inactive, active);
+
+        MembershipSorter sorter = new MembershipSorter(list);
+        assertThat(sorter.sort()).containsExactly(active, inactive);
+    }
+
+    @Test
+    public void returnsEmptyListForNull() {
+        List<Membership> result = new MembershipSorter(null).sort();
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void fallsBackToGroupNameComparison() {
+        Membership ms1 = new Membership();
+        Group g1 = new Group();
+        g1.setName("a");
+        ms1.setGroup(g1);
+
+        Membership ms2 = new Membership();
+        Group g2 = new Group();
+        g2.setName("b");
+        ms2.setGroup(g2);
+
+        List<Membership> result = new MembershipSorter(Arrays.asList(ms2, ms1)).sort();
+        assertThat(result).containsExactly(ms1, ms2);
+    }
+}

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/AccountManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/AccountManagerBean.java
@@ -7,22 +7,20 @@ import hu.sch.domain.user.LostPasswordToken;
 import hu.sch.domain.user.User;
 import hu.sch.domain.user.UserStatus;
 import static hu.sch.ejb.MailManagerBean.getMailString;
-import hu.sch.services.config.Configuration;
 import hu.sch.services.AccountManager;
 import hu.sch.services.Roles;
 import hu.sch.services.SystemManagerLocal;
 import hu.sch.services.UserManagerLocal;
+import hu.sch.services.config.Configuration;
 import hu.sch.services.exceptions.DuplicatedUserException;
-import hu.sch.util.exceptions.PekException;
 import hu.sch.util.exceptions.PekErrorCode;
+import hu.sch.util.exceptions.PekException;
 import hu.sch.util.hash.Hashing;
 import java.io.UnsupportedEncodingException;
 import java.security.SecureRandom;
 import java.util.Date;
 import java.util.Random;
-import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import javax.ejb.EJB;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -56,11 +54,11 @@ public class AccountManagerBean implements AccountManager {
     @PersistenceContext
     private EntityManager em;
     //
-    @EJB(name = "UserManagerBean")
+    @Inject
     private UserManagerLocal userManager;
-    @EJB(name = "SystemManagerBean")
+    @Inject
     private SystemManagerLocal systemManager;
-    @EJB
+    @Inject
     private MailManagerBean mailManager;
     @Resource
     private SessionContext sessionContext;

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/MembershipManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/MembershipManagerBean.java
@@ -15,8 +15,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
@@ -39,7 +39,7 @@ public class MembershipManagerBean implements MembershipManagerLocal {
 
     @PersistenceContext
     private EntityManager em;
-    @EJB
+    @Inject
     LogManagerLocal logManager;
 
     @Override

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/RegistrationManager.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/RegistrationManager.java
@@ -15,8 +15,8 @@ import hu.sch.util.exceptions.PekException;
 import hu.sch.services.exceptions.UserAlreadyExistsException;
 import hu.sch.services.exceptions.UserNotFoundException;
 import java.util.Date;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -34,9 +34,9 @@ public class RegistrationManager implements RegistrationManagerLocal {
     @PersistenceContext
     private EntityManager em;
     //
-    @EJB(name = "UserManagerBean")
+    @Inject
     private UserManagerLocal userManager;
-    @EJB(name = "AccountManagerBean")
+    @Inject
     private AccountManager accountManager;
     //
     private static final Logger logger = LoggerFactory.getLogger(RegistrationManager.class);

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SvieManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SvieManagerBean.java
@@ -92,7 +92,7 @@ public class SvieManagerBean implements SvieManagerLocal {
 
     @Override
     public List<User> getSvieMembers() {
-        Query q = em.createNamedQuery(Membership.getMembers);
+        Query q = em.createNamedQuery(Membership.getMembersWithSvieMembershipTypeNotEqual);
         q.setParameter("msType", SvieMembershipType.NEMTAG);
         return q.getResultList();
     }

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SvieManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SvieManagerBean.java
@@ -12,8 +12,8 @@ import hu.sch.services.MembershipManagerLocal;
 import hu.sch.services.SvieManagerLocal;
 import hu.sch.services.SystemManagerLocal;
 import java.util.List;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -29,15 +29,15 @@ import org.slf4j.LoggerFactory;
 public class SvieManagerBean implements SvieManagerLocal {
 
     private static Logger logger = LoggerFactory.getLogger(SvieManagerBean.class);
-    @EJB
+    @Inject
     private GroupManagerLocal groupManager;
-    @EJB
+    @Inject
     private MembershipManagerLocal membershipManager;
-    @EJB
+    @Inject
     private MailManagerBean mailManager;
-    @EJB(name = "LogManagerBean")
+    @Inject
     private LogManagerLocal logManager;
-    @EJB
+    @Inject
     private SystemManagerLocal systemManager;
     @PersistenceContext
     private EntityManager em;

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SystemManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/SystemManagerBean.java
@@ -8,7 +8,6 @@ import hu.sch.services.SystemManagerLocal;
 import hu.sch.services.exceptions.NoSuchAttributeException;
 import java.util.Map;
 import javax.annotation.PostConstruct;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -37,7 +36,7 @@ public class SystemManagerBean implements SystemManagerLocal {
     //
     @PersistenceContext
     EntityManager em;
-    @EJB
+    @Inject
     MailManagerBean mailManager;
 
     @PostConstruct

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/TimerServiceBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/TimerServiceBean.java
@@ -12,9 +12,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.ejb.EJB;
 import javax.ejb.Schedule;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -31,13 +31,13 @@ import org.slf4j.LoggerFactory;
 public class TimerServiceBean {
 
     private static final Logger logger = LoggerFactory.getLogger(TimerServiceBean.class);
-    @EJB
+    @Inject
     private MailManagerBean mailManager;
-    @EJB(name = "SystemManagerBean")
+    @Inject
     private SystemManagerLocal systemManager;
-    @EJB
+    @Inject
     private GroupManagerLocal groupManager;
-    @EJB
+    @Inject
     private AccountManager accountManager;
     @PersistenceContext
     private EntityManager em;

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/UserManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/UserManagerBean.java
@@ -35,7 +35,7 @@ public class UserManagerBean implements UserManagerLocal {
 
     private static Logger logger = LoggerFactory.getLogger(UserManagerBean.class);
     @PersistenceContext
-    EntityManager em;
+    private EntityManager em;
     private SystemManagerLocal systemManager;
     private Configuration config;
 

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/UserManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/UserManagerBean.java
@@ -1,6 +1,5 @@
 package hu.sch.ejb;
 
-import hu.sch.domain.enums.ValuationStatus;
 import hu.sch.domain.user.User;
 import hu.sch.domain.*;
 import hu.sch.services.config.Configuration;
@@ -17,7 +16,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.*;
@@ -38,15 +36,7 @@ public class UserManagerBean implements UserManagerLocal {
     private static Logger logger = LoggerFactory.getLogger(UserManagerBean.class);
     @PersistenceContext
     EntityManager em;
-    @EJB(name = "LogManagerBean")
-    LogManagerLocal logManager;
-    @EJB
-    MailManagerBean mailManager;
-    @EJB
-    AccountManager accountManager;
-    @EJB(name = "PostManagerBean")
-    PostManagerLocal postManager;
-    @EJB
+    @Inject
     private SystemManagerLocal systemManager;
     //
     @Inject

--- a/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/ValuationManagerBean.java
+++ b/sch-pek-ejb-impl/src/main/java/hu/sch/ejb/ValuationManagerBean.java
@@ -37,10 +37,10 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.OptimisticLockException;
@@ -62,13 +62,13 @@ public class ValuationManagerBean implements ValuationManagerLocal {
     private static final Logger logger = LoggerFactory.getLogger(ValuationManagerBean.class);
     @PersistenceContext
     EntityManager em;
-    @EJB
+    @Inject
     private UserManagerLocal userManager;
-    @EJB
+    @Inject
     private SystemManagerLocal systemManager;
-    @EJB
+    @Inject
     private MailManagerBean mailManager;
-    @EJB
+    @Inject
     private GroupManagerLocal groupManager;
 
     @Override

--- a/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/RecommendedPhotoTest.java
+++ b/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/RecommendedPhotoTest.java
@@ -3,7 +3,6 @@ package hu.sch.ejb.test.user;
 import hu.sch.domain.SpotImage;
 import hu.sch.services.config.ImageUploadConfig;
 import hu.sch.domain.user.User;
-import hu.sch.ejb.EjbConstructorArgument;
 import hu.sch.ejb.UserManagerBean;
 import hu.sch.services.config.Configuration;
 import hu.sch.ejb.test.base.AbstractDatabaseBackedTest;
@@ -27,9 +26,8 @@ public class RecommendedPhotoTest extends AbstractDatabaseBackedTest {
         Configuration cfg =  mock(Configuration.class);
         when(cfg.getImageUploadConfig()).thenReturn(new ImageUploadConfig("/", 200));
 
-        final EjbConstructorArgument args = new EjbConstructorArgument(getEm());
-        args.setConfig(cfg);
-        bean = new UserManagerBean(args);
+        bean = new UserManagerBean(getEm());
+        bean.setConfig(cfg);
         createUser();
     }
 
@@ -45,7 +43,7 @@ public class RecommendedPhotoTest extends AbstractDatabaseBackedTest {
         UserBuilder b = new UserBuilder().withNeptun(neptun);
         User user = b.build();
         user.setShowRecommendedPhoto(true);
-        
+
         SpotImage img = new SpotImage();
         img.setImagePath("");
         img.setNeptunCode(neptun);

--- a/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/UserFinderTest.java
+++ b/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/UserFinderTest.java
@@ -4,7 +4,6 @@
  */
 package hu.sch.ejb.test.user;
 
-import hu.sch.ejb.EjbConstructorArgument;
 import hu.sch.ejb.UserManagerBean;
 import hu.sch.ejb.test.base.AbstractDatabaseBackedTest;
 import hu.sch.ejb.test.builder.UserBuilder;
@@ -22,7 +21,7 @@ public class UserFinderTest extends AbstractDatabaseBackedTest {
     @Override
     protected void before() {
         new UserBuilder().withNeptun("ABCDEF").create(getEm());
-        bean = new UserManagerBean(new EjbConstructorArgument(getEm()));
+        bean = new UserManagerBean(getEm());
     }
 
     @Test

--- a/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/UserPrivateAttributeTest.java
+++ b/sch-pek-ejb-impl/src/test/java/hu/sch/ejb/test/user/UserPrivateAttributeTest.java
@@ -3,7 +3,6 @@ package hu.sch.ejb.test.user;
 import hu.sch.domain.user.User;
 import hu.sch.domain.user.UserAttribute;
 import hu.sch.domain.user.UserAttributeName;
-import hu.sch.ejb.EjbConstructorArgument;
 import hu.sch.ejb.UserManagerBean;
 import hu.sch.ejb.test.base.AbstractDatabaseBackedTest;
 import hu.sch.ejb.test.builder.UserBuilder;
@@ -50,9 +49,9 @@ public class UserPrivateAttributeTest extends AbstractDatabaseBackedTest {
         Long id = setupUserWithVisibleEmailAttribute();
         User user = getEm().find(User.class, id);
 
-        UserManagerBean bean = new UserManagerBean(new EjbConstructorArgument(getEm()));
+        UserManagerBean bean = new UserManagerBean(getEm());
         bean.invertAttributeVisibility(user, UserAttributeName.EMAIL);
-        
+
         getEm().flush();
         getEm().clear();
 

--- a/sch-pek-ejb-services/src/main/java/hu/sch/services/UserManagerLocal.java
+++ b/sch-pek-ejb-services/src/main/java/hu/sch/services/UserManagerLocal.java
@@ -31,12 +31,12 @@ public interface UserManagerLocal {
     /**
      * Gets the user with the specified id.
      *
+     * It also includes the user's memberships, groups and posts.
+     *
      * @param userId
-     * @param includeMemberships set it to true and it prefetches the
-     * memberships
      * @return the user or null if there is no user with the id
      */
-    User findUserById(Long userId, boolean includeMemberships);
+    User findUserByIdWithMemberships(Long userId);
 
     /**
      * Gets the users whose name contains the given fragment.

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/response/AbstractEntityView.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/response/AbstractEntityView.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public abstract class AbstractEntityView<T> implements EntityView {
 
-    private Class<T> entityClass;
+    private final Class<T> entityClass;
     protected final T entity;
 
     public AbstractEntityView(T entity, Class<T> clazz) {

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
@@ -1,0 +1,50 @@
+package hu.sch.api.user;
+
+import hu.sch.api.response.AbstractEntityView;
+import hu.sch.domain.Membership;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+/**
+ *
+ * @author tomi
+ */
+public class MembershipView extends AbstractEntityView<Membership> {
+
+
+
+    public MembershipView(Membership entity) {
+        super(entity, Membership.class);
+    }
+
+    public static List<MembershipView> fromCollection(Collection<Membership> collection) {
+        List<MembershipView> result = new ArrayList<>();
+        for (Membership membership : collection) {
+            result.add(new MembershipView(membership));
+        }
+
+        return result;
+    }
+
+    public Long getId() {
+        return entity.getId();
+    }
+
+    public String getGroupName() {
+        return entity.getGroup().getName();
+    }
+
+    public Date getStart() {
+        return entity.getStart();
+    }
+
+    public Date getEnd() {
+        return entity.getEnd();
+    }
+
+    public List<String> getPosts() {
+        return entity.getAllPosts();
+    }
+}

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
@@ -2,6 +2,7 @@ package hu.sch.api.user;
 
 import hu.sch.api.response.AbstractEntityView;
 import hu.sch.domain.Membership;
+import hu.sch.domain.util.MembershipSorter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -20,8 +21,9 @@ public class MembershipView extends AbstractEntityView<Membership> {
     }
 
     public static List<MembershipView> fromCollection(Collection<Membership> collection) {
+        MembershipSorter sorter = new MembershipSorter(collection);
         List<MembershipView> result = new ArrayList<>();
-        for (Membership membership : collection) {
+        for (Membership membership : sorter.sort()) {
             result.add(new MembershipView(membership));
         }
 

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/user/MembershipView.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -22,12 +23,10 @@ public class MembershipView extends AbstractEntityView<Membership> {
 
     public static List<MembershipView> fromCollection(Collection<Membership> collection) {
         MembershipSorter sorter = new MembershipSorter(collection);
-        List<MembershipView> result = new ArrayList<>();
-        for (Membership membership : sorter.sort()) {
-            result.add(new MembershipView(membership));
-        }
-
-        return result;
+        return sorter.sort()
+                .stream()
+                .map(ms -> new MembershipView(ms))
+                .collect(Collectors.toList());
     }
 
     public Long getId() {

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/user/Users.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/user/Users.java
@@ -1,7 +1,5 @@
 package hu.sch.api.user;
 
-import hu.sch.api.response.PekResponse;
-import hu.sch.api.response.PekSuccess;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 

--- a/sch-pek-internal-api/src/main/java/hu/sch/api/user/UsersMembersips.java
+++ b/sch-pek-internal-api/src/main/java/hu/sch/api/user/UsersMembersips.java
@@ -1,0 +1,32 @@
+package hu.sch.api.user;
+
+import hu.sch.api.exceptions.EntityNotFoundException;
+import hu.sch.domain.user.User;
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ *
+ * @author tomi
+ */
+@Path(UsersBase.PATH +  "/memberships")
+public class UsersMembersips extends UsersBase {
+
+    @GET
+    public List<MembershipView> getMemberships() {
+        User user = fetchUser();
+        return MembershipView.fromCollection(user.getMemberships());
+    }
+
+    @Override
+    protected User fetchUser() {
+        User user = userManager.findUserByIdWithMemberships(id);
+        if (user == null) {
+            throw new EntityNotFoundException(User.class);
+        }
+        return user;
+    }
+
+
+}


### PR DESCRIPTION
Alapvetően a körtagságok listázásához szükséges dolgok vannak itt, némi becsúszott refaktorálással.
- `@EJB`-ket `@Inject`-re cseréltem
- körkörös injektálást feloldottam (csak bent maradt változók voltak)
- a membershipeket betöltő query-t kiigazítottam, hogy ne `n+1` query-ben töltse le az adatbázisból a tagságokat és a hozzá tartozó adatokat.
- UserManagerBean teszt barátabbá tétele (setter injectionnel)

Hosszabb távon majd az `EjbConstructorArgument` osztályt fel kell számolni. Ez már anno is hacknek tűnt.
